### PR TITLE
fix: update release name to' v#.#.#'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.create_tag.outputs.tag_name }}
-          name: "Release v${{ steps.pubspec.outputs.full_version }}"
+          name: "v${{ steps.pubspec.outputs.semantic_version }}"
           body: ${{ steps.prep_release_body.outputs.body }}
           draft: false
           prerelease: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.0+1
+version: 0.2.1+1
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
### Fixes
- change release name from Release `v0.2.0+19` to `v0.2.0`


closes #11 
